### PR TITLE
Remove William Rizzo from the contributors list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,5 +14,4 @@ These are active contributors who have made multiple contributions to the projec
 | Martin Schuessler   | [@c0ffee](https://github.com/c0ffee)                   |
 | Andreas Reitz       | [@areitz86](https://github.com/areitz86)               |
 | Ben Corrado         | [@bencorrado](https://github.com/bencorrado)           |
-| William Rizzo       | [@wrkode](https://github.com/wrkode)                   |
 | Jasper De Keukelaere| [@jasperdekeuk](https://github.com/jasperdekeuk)       |


### PR DESCRIPTION
William is now a maintainer and we will try to keep track of people just in one of the lists